### PR TITLE
Include frontmatter and a back cover page

### DIFF
--- a/_zines/condition_text.py
+++ b/_zines/condition_text.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 
@@ -45,6 +46,17 @@ if __name__ == "__main__":
         )
     )
 
+    blurb = ""  # if a blurb is available, use it
+    if os.path.exists("blurb.md"):
+        with open("blurb.md") as fobj:
+            blurb = fobj.read().replace("\n", " ")
+
     # overwrite the original file
     with open(sys.argv[1], "w") as fobj:
-        fobj.write(contents)
+        fobj.write(
+            re.sub(
+                "description: (.*)",
+                f"description: {blurb}",
+                contents
+            )
+        )

--- a/_zines/impose.tex
+++ b/_zines/impose.tex
@@ -19,6 +19,6 @@
 
 % dash means all pages, signature is number of pages in each package
 % landscape of course means reorient single pages by 90°
-\includepdf[pages=-,signature=22,landscape]{raw.pdf}
+\includepdf[pages=-,signature=28,landscape]{raw.pdf}
 
 \end{document}

--- a/_zines/zine_template.tex
+++ b/_zines/zine_template.tex
@@ -1,9 +1,9 @@
 % -- preamble -----------------------------------------------------------------
 
-\documentclass{article}
-\usepackage{bigfoot,caption,graphicx,hyperref}
+\documentclass[12pt]{article}
+\usepackage{bigfoot,caption,graphicx,hyperref,ifoddpage}
 \usepackage[nodayofweek]{datetime}
-\usepackage[a4paper,total={6in,9in}]{geometry}
+\usepackage[a4paper,total={6in,9.5in}]{geometry}
 
 % -- fonts
 \usepackage[T1]{fontenc}
@@ -16,6 +16,9 @@
 \titleformat*{\subsection}{\large\bf\sffamily}
 \titleformat*{\subsubsection}{\normalsize\bf\sffamily}
 \setcounter{secnumdepth}{0}
+
+% -- blank page object
+\def\blankpage{\clearpage\thispagestyle{empty}\null\clearpage}
 
 % -- text spacing
 \setlength{\parskip}{1em}
@@ -51,6 +54,7 @@
 
 \begin{document}
 
+% -- title page
 \begin{titlepage}
     \centering
     \vspace*{5cm}
@@ -62,9 +66,40 @@
     {\LARGE \longdate\today}
 \end{titlepage}
 
-\tableofcontents
+% -- frontmatter
+\thispagestyle{empty}
+\setcounter{page}{2}
+\vspace*{6cm}
+\textsc{Where Many Worlds Fit} is a podcast about radical autonomy. It is
+interested in lessons about education, restorative justice, prefiguration,
+ecology, organization, and many, many other things, through conversation
+with active libertarian movements around the world. Many of these movements
+emerge from the natural union of long-held indigenous traditions with more
+modern political philosophy, and support diverse, pluralistic societies of
+millions of people. They are worlds where many worlds fit.
+
+For more information, please visit \texttt{https://manyworldspod.github.io}.
 \clearpage
 
+% -- table of contents
+\thispagestyle{empty}
+\tableofcontents
+\clearpage
+\blankpage
+
+% -- article contents
 $body$
+
+% -- back cover
+\clearpage
+\checkoddpage
+\ifoddpage
+    \blankpage
+\fi
+\thispagestyle{empty}
+\vspace*{6cm}
+\noindent\HRule \\[0.5cm]
+\textit{\large $description$} \\[0.3cm]
+\HRule
 
 \end{document}


### PR DESCRIPTION
This PR incorporates a couple of related major changes:

* Include boilerplate frontmatter about the podcast
* Include a back cover page with a zine-specific blurb

To include a blurb, one must write it to a file called `blurb.md` before running `make`.

This also includes a number of minor formatting enhancements:

* Blank page after the TOC sth. content always starts on the right-hand side
* Auto-detect page count and stick a blank page before the back cover if the count is odd
* Embiggen the text and ensmallen the vertical margins