### PR TITLE
Add a zine link to featured posts

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -12,8 +12,6 @@ menu:
     url:  'about'
   - name: 'episodes'
     url:  'episodes'
-  - name: 'zines'
-    url:  'zines'
   - name: 'rojava'
     url:  'rojava'
   - name: 'zapatistas'

--- a/_includes/featured-post.html
+++ b/_includes/featured-post.html
@@ -1,7 +1,14 @@
 <article>
-  <a href="{{ site.github.url }}{{ post.url }}">
-    <div class="featured-post" {% if post.image %}style="background-image:url({{ site.github.url }}/assets/img/{{ post.slug }}/{{ post.image }})"{% endif %}>
-      <h2><span>{{ post.title }}</span></h2>
-    </div>
-  </a>
+  <div class="featured-post" {% if post.image %}style="background-image:url({{ site.github.url }}/assets/img/{{ post.slug }}/{{ post.image }})"{% endif %}>
+    <h2>
+      <span><a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a></span>
+      <span>
+        {% if post.zine %}
+          <a href="{{ site.github.url }}/assets/zines/{{ post.slug }}.pdf" title="capture this article as a zine" target="_blank">
+            <i class="fa-solid fa-book"></i>
+          </a>
+        {% endif %}
+      </span>
+    </h2>
+  </div>
 </article>

--- a/_posts/2022-03-09-restorative-justice-northeast-syria.md
+++ b/_posts/2022-03-09-restorative-justice-northeast-syria.md
@@ -7,6 +7,7 @@ tags: [rojava,restorative justice,jiniology,dual power,complementarity]
 image: jinwar.jpg
 image_caption_short: "Residents tending a garden in the women's village of Jinwar"
 image_caption: "Residents tending a garden in the women's village of Jinwar (source: <a href=\"https://www.youtube.com/watch?v=ig_Yo1iVM7U\">Jinwar - Free women's Village Rojava</a>)"
+zine: true
 ---
 
 ## Introduction

--- a/_zines/Makefile
+++ b/_zines/Makefile
@@ -16,4 +16,5 @@
 
 clean:
 	# remove intermediate publishing products
-	- rm -rf __pycache__ *.{aux,log,md,pdf}
+	- find . -maxdepth 1 ! -name "README.md" -name "*.md" -delete
+	- rm -rf __pycache__ *.{aux,log,pdf}


### PR DESCRIPTION
This PR finds a more obvious way for readers to discover zines. In addition to being in the footer on the post itself, now a zine link will appear within the background image of featured posts on the landing page.

This also includes a bugfix: in the zines `Makefile`, avoid removing the README by using `find` to exclude it from the `*.md` wildcard.

This is related to #5