### PR TITLE
Refine site structure and maintenance with GitHub Actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+*.lock
 
 # MacBook files
 .DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -7,13 +7,13 @@ paginate: 5
 markdown:    kramdown
 highlighter: rouge
 permalink:   /:title
-plugins:     [jekyll-paginate-v2, jekyll-sitemap, jekyll-feed, jekyll-seo-tag]
+plugins:     [jekyll-paginate, jekyll-sitemap, jekyll-feed, jekyll-seo-tag]
 
 # customise atom feed settings
 # (this is where Jekyll-Feed gets configuration information)
 title:       "Where Many Worlds Fit"
-author:      "nunya"
 description: "a podcast about radical autonomy"
+author:      "nunya"
 
 # RSS 2.0 can be used instead of Atom by uncommenting following two lines
 #feed:

--- a/_includes/featured-post.html
+++ b/_includes/featured-post.html
@@ -2,13 +2,13 @@
   <div class="featured-post" {% if post.image %}style="background-image:url({{ site.github.url }}/assets/img/{{ post.slug }}/{{ post.image }})"{% endif %}>
     <h2>
       <span><a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a></span>
-      <span>
-        {% if post.zine %}
+      {% if post.zine %}
+        <span>
           <a href="{{ site.github.url }}/assets/zines/{{ post.slug }}.pdf" title="capture this article as a zine" target="_blank">
             <i class="fa-solid fa-book"></i>
           </a>
-        {% endif %}
-      </span>
+        </span>
+      {% endif %}
     </h2>
   </div>
 </article>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,6 +7,7 @@ title: Home
   {% include featured-post.html %}
 {% endfor %}
 
+{% if paginator.total_pages > 1 %}
 <!-- Pagination links -->
 <div class="pagination">
   {% if paginator.next_page %}
@@ -20,3 +21,4 @@ title: Home
     <span class="pagination-button">{{ site.data.settings.pagination.next_page }}</span>
   {% endif %}
 </div>
+{% endif %}

--- a/manyworlds.gemspec
+++ b/manyworlds.gemspec
@@ -7,15 +7,16 @@ Gem::Specification.new do |spec|
   spec.email         = ["many.worlds.pod@protonmail.com"]
 
   spec.summary       = "A minimalist Jekyll theme for the Where Many Worlds Fit podcast"
-  spec.homepage      = "https://github.com/manyworldspod/manyworldspod.github.io"
+  spec.homepage      = "https://github.com/manyworldspod/"
   spec.license       = "CC0-1.0"
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|CHANGELOG)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> 4.2"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.16"
-  spec.add_runtime_dependency "jekyll-paginate-v2", "~> 3.0"
-  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
+  spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.8"
+  spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
+  spec.add_runtime_dependency "webrick", "~> 1.7"
 
 end


### PR DESCRIPTION
Just a couple of minor enhancements:

* Go back to using `jekyll-paginate` per [these guidelines](https://jekyllrb.com/docs/pagination/)
* Hide previous/next buttons if there are fewer than five posts
* For articles not to be zinified, don't include a `span`
* Ignore `*.lock` files from local testing
* Support Jekyll >= 3