### PR TITLE
Introduce a last modified date where appropriate

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -38,7 +38,8 @@ pagination:
   previous_page: 'older'
 
 # customize post formatting
-byline_prefix: 'by'
+byline_prefix: 'filed by'
 post_date_prefix: 'published'
+last_modified_prefix: 'last modified'
 sharing_button_prompt: 'steal this page!'
 related_posts: 'related coverage'

--- a/_includes/post-byline.html
+++ b/_includes/post-byline.html
@@ -8,12 +8,11 @@
 </span>
 <span class="post-date">
   {{ site.data.settings.post_date_prefix }}
-  {% assign d = page.date | date: "%-d"  %}
-  {{ page.date | date: "%B" }}
-  {% case d %}
-    {% when '1' or '21' or '31' %}{{ d }}st
-    {% when '2' or '22' %}{{ d }}nd
-    {% when '3' or '23' %}{{ d }}rd
-    {% else %}{{ d }}th{% endcase %},
-  {{ page.date | date: "%Y" }}
+  {{ page.date | date: "%-d %B %Y" }}
 </span>
+{% if page.last_modified %}
+  <span class="post-date">
+    {{ site.data.settings.last_modified_prefix }}
+    {{ page.last_modified | date: "%-d %B %Y" }}
+  </span>
+{% endif %}

--- a/_posts/2022-03-09-restorative-justice-northeast-syria.md
+++ b/_posts/2022-03-09-restorative-justice-northeast-syria.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Restorative Justice in Northeast Syria"
 author: "heval ashtabula"
+last_modified: 2022-03-11
 categories: justice
 tags: [rojava,restorative justice,jiniology,dual power,complementarity]
 image: jinwar.jpg

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -17,7 +17,7 @@ figcaption {
   text-align: justify;
   text-justify: inter-word;
 }
-.post-date, .share-prompt {
+.post-date:last-of-type, .share-prompt {
   margin-bottom: 1rem;
 }
 .featured-image img {


### PR DESCRIPTION
This PR fixes #9 by implementing a "last modified" descriptor in the bylines of articles. This data comes from markdown frontmatter; if it isn't explicitly set, it isn't printed.