### PR TITLE
Prepare zines from markdown files we already have

### DIFF
--- a/_includes/featured-post.html
+++ b/_includes/featured-post.html
@@ -1,5 +1,5 @@
 <article>
-  <div class="featured-post" {% if post.image %}style="background-image:url({{ site.github.url }}/assets/img/{{ post.slug }}/{{ post.image }})"{% endif %}>
+  <div class="featured-post" {% if post.images %}style="background-image:url({{ site.github.url }}/assets/img/{{ post.slug }}/{{ post.images[0].url }})"{% endif %}>
     <h2>
       <span><a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a></span>
       {% if post.zine %}

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,0 +1,4 @@
+<figure>
+  <img src="{{ site.github.url }}/assets/img/{{ include.slug }}/{{ include.image.url }}" title="{{ include.image.title }}">
+  <figcaption>{{ include.image.alt | markdownify | remove: "<p>" | remove: "</p>" }}</figcaption>
+</figure>

--- a/_posts/2022-03-09-restorative-justice-northeast-syria.md
+++ b/_posts/2022-03-09-restorative-justice-northeast-syria.md
@@ -1,15 +1,49 @@
 ---
 layout: post
-title: "Restorative Justice in Northeast Syria"
-author: "heval ashtabula"
+title: Restorative Justice in Northeast Syria
+author: heval ashtabula
 last_modified: 2022-03-11
+blurb: >-
+  Imagine that, for one reason or another, state authorities retreated
+  from your area. For all intents and purposes the government was just
+  ***gone*** one day. How would you organize your community?
 categories: justice
 tags: [rojava,restorative justice,jiniology,dual power,complementarity]
-image: jinwar.jpg
-image_caption_short: "Residents tending a garden in the women's village of Jinwar"
-image_caption: "Residents tending a garden in the women's village of Jinwar (source: <a href=\"https://www.youtube.com/watch?v=ig_Yo1iVM7U\">Jinwar - Free women's Village Rojava</a>)"
+images:
+  - url: jinwar.jpg
+    alt: >-
+      Residents tending a garden in the women's village of Jinwar
+      (source: [Jinwar - Free women's Village Rojava](
+      href="https://www.youtube.com/watch?v=ig_Yo1iVM7U))
+    title: >-
+      Residents tending a garden in the women's village of Jinwar
+  - url: kurdistan.jpg
+    alt: >-
+      Geographic spread of modern Kurdistan across the states of Iraq, Iran,
+      Turkey, and Syria (source:
+      [The Kurdish Project](https://thekurdishproject.org))
+    title: Geographic spread of modern Kurdistan
+  - url: rojava.png
+    alt: >-
+      Geographic layout of Rojava circa 2019 (source:
+      [Emergency Committee for Rojava](https://defendrojava.org))
+    title: Geographic layout of Rojava
+  - url: grandma.png
+    alt: A neighborhood elder on armed patrol
+    title: Neighborhood elder on armed patrol
+  - url: sehid.png
+    alt: >-
+      Public celebration of şehîd Hevrîn Xelef, a civil engineer who led the
+      formative efforts to improve civil society in Rojava. She also managed
+      one of the economic councils and became co-chair of the energy authority
+      in 2016.
+    title: Celebration for a şehîd
 zine: true
 ---
+
+{% assign slug = page.slug %}
+{% assign image = page.images[0] %}
+{% include figure.html image=image slug=slug %}
 
 ## Introduction
 
@@ -108,18 +142,8 @@ is to sow that seed — as praxis, right here in our own community.
 
 ---
 
-<figure>
-  <img
-    src="https://manyworldspod.github.io/assets/img/restorative-justice-northeast-syria/kurdistan.jpg"
-    alt="geographic spread of modern Kurdistan"
-    title="geographic spread of modern Kurdistan">
-  <figcaption>
-    Geographic spread of modern Kurdistan across the states of Iraq, Iran,
-    Turkey, and Syria (source:
-    <a href="https://thekurdishproject.org">The Kurdish Project</a>
-    )
-  </figcaption>
-</figure>
+{% assign image = page.images[1] %}
+{% include figure.html image=image slug=slug %}
 
 Understanding the cultural revolution in Rojava requires historical context. A
 fully honest discussion would probably start with European imperialism, World
@@ -159,17 +183,8 @@ assemblies formed a functioning grassroots democracy, and in mid 2014 the first
 formal Constitution of Rojava had been approved, establishing the Autonomous
 Administration of North and East Syria (AANES).
 
-<figure>
-  <img
-    src="https://manyworldspod.github.io/assets/img/restorative-justice-northeast-syria/rojava.png"
-    alt="geographic layout of Rojava"
-    title="geographic layout of Rojava">
-  <figcaption>
-    Geographic layout of Rojava circa 2019 (source:
-    <a href="https://defendrojava.org">Emergency Committee for Rojava</a>
-    )
-  </figcaption>
-</figure>
+{% assign image = page.images[2] %}
+{% include figure.html image=image slug=slug %}
 
 Since that time, the YPG have forged a coalition with other autonomous militia
 groups under the umbrella of the Syrian Democratic Forces (SDF). These include
@@ -248,13 +263,8 @@ involve a mediator from this branch whose role is to act as a security blanket,
 encouraging women to share traumatic experiences while reminding the
 journalists that consent can be revoked at any time.
 
-<figure>
-  <img
-    src="https://manyworldspod.github.io/assets/img/restorative-justice-northeast-syria/grandma.png"
-    alt="Neighborhood elder on armed patrol"
-    title="Neighborhood elder on armed patrol">
-  <figcaption>A neighborhood elder on armed patrol</figcaption>
-</figure>
+{% assign image = page.images[3] %}
+{% include figure.html image=image slug=slug %}
 
 At the neighborhood level, unarmed local grandmothers are often first
 responders to community problems. Their role is to facilitate peace after major
@@ -343,18 +353,8 @@ who beats his wife is socially ostracized and domestic violence seems to have
 vanished. In 2017 there were approximately 200 divorces, mostly due to cases of
 polygamy and child marriage.*
 
-<figure>
-  <img
-    src="https://manyworldspod.github.io/assets/img/restorative-justice-northeast-syria/sehid.png"
-    alt="Celebration for a şehîd"
-    title="Celebration for a şehîd">
-  <figcaption>
-    Public celebration of şehîd Hevrîn Xelef, a civil engineer who led the
-    formative efforts to improve civil society in Rojava. She also managed one
-    of the economic councils and became co-chair of the energy authority in
-    2016.
-  </figcaption>
-</figure>
+{% assign image = page.images[4] %}
+{% include figure.html image=image slug=slug %}
 
 In late 2020, partly due to the COVID-19 pandemic and partly due to an
 unsustainable influx in ISIS prisoners, the administration announced general

--- a/_posts/2022-03-09-restorative-justice-northeast-syria.md
+++ b/_posts/2022-03-09-restorative-justice-northeast-syria.md
@@ -2,6 +2,7 @@
 layout: post
 title: Restorative Justice in Northeast Syria
 author: heval ashtabula
+date: 2022-03-09
 last_modified: 2022-03-11
 blurb: >-
   Imagine that, for one reason or another, state authorities retreated
@@ -14,7 +15,7 @@ images:
     alt: >-
       Residents tending a garden in the women's village of Jinwar
       (source: [Jinwar - Free women's Village Rojava](
-      href="https://www.youtube.com/watch?v=ig_Yo1iVM7U))
+      https://www.youtube.com/watch?v=ig_Yo1iVM7U))
     title: >-
       Residents tending a garden in the women's village of Jinwar
   - url: kurdistan.jpg

--- a/_zines/Makefile
+++ b/_zines/Makefile
@@ -2,14 +2,11 @@
 # NOTE: this requires Pandoc and PDFLaTeX in the run environment
 
 %:
-	# convert the formatted web post back to markdown
-	# this is done to properly capture images, captions, and links
-	- pandoc -s -r html https://manyworldspod.github.io/$@ -o $@.md
-	# remove vestiges of the website's header and footer,
-	# and do a few other minor formatting enhancements
-	- python -m condition_text $@.md
+	# capture figures with captions, and
+	# other minor formatting enhancements
+	- python -m condition_text $@
 	# convert the markdown to PDF
-	- pandoc $@.md --defaults defaults.yml -o raw.pdf
+	- pandoc source.md --defaults defaults.yml -o raw.pdf
 	# finally, impose two script pages per A4 page
 	# NOTE: please check the settings in impose.tex for this article
 	- pdflatex impose && mv impose.pdf ../assets/zines/$@.pdf

--- a/_zines/README.md
+++ b/_zines/README.md
@@ -19,21 +19,19 @@ purposes any currently supported version will do.
 
 ## Optional: blurb for the back cover
 
-If there is text you'd like to include as a blurb on the zine's back cover, you
-can write it to a file called `blurb.md`, with all the markdown formatting you
-like. For example,
+If there is text you'd like to include as a blurb on the zine's back cover,
+you can write it to a frontmatter variable called `blurb` with all the usual
+markdown formatting. For example,
 
 
 ```markdown
-This is a sentence with some _emphatic ideas_ and some **bold claims**.
+blurb: >-
+  This is a sentence with some _emphatic ideas_ and some **bold claims**.
 ```
 
 will be rendered as:
 
 > This is a sentence with some _emphatic ideas_ and some **bold claims**.
-
-Note, if your blurb is longer than a paragraph you will have to format it by
-hand with HTML tags.
 
 ## Render the imposed PDF
 
@@ -69,7 +67,7 @@ Some other notes:
 
 ### But wait!
 
-Before you share your zine publicly, you'll want to compare the output of the
+Before you share your zine publicly, you should compare the draft of the
 imposed version (`/assets/zines/<slug>.pdf`) to the raw version (`raw.pdf` in
 this directory). If something seems off, _e.g._ there are pages missing, it's
 likely because of a setting in `impose.tex`. You'll find it if you open that
@@ -89,18 +87,15 @@ another one, or if you have a feature request, please post an
 
 ## For my fellow nerds: what's happening under the hood?
 
-The `Makefile` implements a 4-step process:
+The `Makefile` implements a 3-step process:
 
-1. Export the article published online to a local markdown file
-2. Remove junk from the website's header and footer, reformat source links
-   inside of figure captions, clean up extraneous things that make sense on
-   a website but not in a PDF, and (optionally) include a blurb for the back
-   cover
-3. Export the markdown to a regular, report-style, one-page-at-a-time PDF
-4. Impose the PDF four pages to a sheet (two on the front, two on the back)
-   and save it in the right location to be discoverable on the website
+1. Condition the original markdown, _i.e._ capture all figures (including
+   captions and placement) and format the text for publication as a zine
+2. Export the markdown to a regular, report-style, one-page-at-a-time PDF
+3. Impose the PDF four pages to a sheet (two on the front, two on the back)
+   and save it in the correct location to be discoverable on the website
 
-Steps 1 and 3 require Pandoc, step 2 requires Python, and steps 3 and 4 require
+Step 1 requires Python, step 2 requires Pandoc, and steps 2 and 3 require
 PDFLateX. If you want to clean up all the scratch work from these steps, you
 can simply run
 
@@ -108,11 +103,5 @@ can simply run
 make clean
 ```
 
-When you're ready to publish to the website, make sure you're on a scratch
+When you're ready to publish to the website, make sure you're on a bespoke
 branch, then push to `origin/<branch>` and open a pull request.
-
-### Why do we need another markdown file? Didn't I post from a markdown to begin with...?
-
-Yep! And I apologize for the confusion. Another markdown is needed to properly
-capture images after they're published to the website. Pandoc's LaTeX engine
-knows how to take these and ship them with the final PDF.

--- a/_zines/README.md
+++ b/_zines/README.md
@@ -12,6 +12,7 @@ following packages installed:
 
 * [PDFLaTeX](https://www.latex-project.org/get/)
 * [Pandoc](https://pandoc.org/installing.html)
+* [python-frontmatter](https://pypi.org/project/python-frontmatter/)
 
 You will also need a [Python](https://www.python.org/) interpreter, for our
 purposes any currently supported version will do.

--- a/_zines/template.tex
+++ b/_zines/template.tex
@@ -2,7 +2,7 @@
 
 \documentclass[12pt]{article}
 \usepackage{bigfoot,caption,graphicx,hyperref,ifoddpage}
-\usepackage[nodayofweek]{datetime}
+\usepackage[en-GB]{datetime2}
 \usepackage[a4paper,total={6in,9.5in}]{geometry}
 
 % -- fonts
@@ -74,7 +74,7 @@
 \vfill
 \noindent\textsc{$title$} \\
 {\small by $for(author)$$author$$sep$ \and $endfor$} \\
-{\small published $date$} \\[4cm]
+{\small published \DTMdate{$date$}} \\[4cm]
 
 \textit{Where Many Worlds Fit} is a podcast about radical autonomy. It is
 interested in lessons about education, restorative justice, prefiguration,

--- a/_zines/template.tex
+++ b/_zines/template.tex
@@ -74,7 +74,7 @@
 \vfill
 \noindent\textsc{$title$} \\
 {\small by $for(author)$$author$$sep$ \and $endfor$} \\
-{\small published $postdate$} \\[4cm]
+{\small published $date$} \\[4cm]
 
 \textit{Where Many Worlds Fit} is a podcast about radical autonomy. It is
 interested in lessons about education, restorative justice, prefiguration,
@@ -111,7 +111,7 @@ $body$
 \null
 \vfill
 \noindent\HRule \\[0.5cm]
-\textit{\large $description$} \\[0.3cm]
+\textit{\large $blurb$} \\[0.3cm]
 \HRule \\[1cm]
 \begin{center}
     \includegraphics{../assets/img/snail-emoji.png}


### PR DESCRIPTION
This PR introduces architecture to render zine PDFs straight from the markdown files we already have:

* Reformat posts sth. images are declared in the YAML frontmatter
* Reconfigure `condition_text.py` to receive a stub, auto-detect the original post, and populate markdown for images
* Update `Makefile` and `README`

This fixes #5 and fixes #21.